### PR TITLE
Fix visualization not working for air-roll

### DIFF
--- a/source/JoystickSelfCheckPlugin/JoystickSelfCheckPlugin.cpp
+++ b/source/JoystickSelfCheckPlugin/JoystickSelfCheckPlugin.cpp
@@ -67,7 +67,7 @@ void JoystickSelfCheckPlugin::Render(CanvasWrapper canvas)
 	{
 		ControllerInput input = *it;
 
-		Vector2 currentPos = { canvasCenter.X + (int)(*joystickVizSize / 2 * input.Yaw) - 3, canvasCenter.Y + (int)(*joystickVizSize / 2 * input.Pitch) - 3 };
+		Vector2 currentPos = { canvasCenter.X + (int)(*joystickVizSize / 2 * input.Steer) - 3, canvasCenter.Y + (int)(*joystickVizSize / 2 * input.Pitch) - 3 };
 
 		canvas.SetColor(255, 255, 255, 255 - i * 2);
 		canvas.SetPosition(currentPos);
@@ -75,9 +75,9 @@ void JoystickSelfCheckPlugin::Render(CanvasWrapper canvas)
 
 		if (i > 0) {
 			ControllerInput prevInput = inputHistory[inputHistory.size() - i - 1];
-			Vector2 prevPos = { canvasCenter.X + (int)(*joystickVizSize / 2 * prevInput.Yaw), canvasCenter.Y + (int)(*joystickVizSize / 2 * prevInput.Pitch) };
+			Vector2 prevPos = { canvasCenter.X + (int)(*joystickVizSize / 2 * prevInput.Steer), canvasCenter.Y + (int)(*joystickVizSize / 2 * prevInput.Pitch) };
 
-			canvas.DrawLine({ canvasCenter.X + (int)(*joystickVizSize / 2 * input.Yaw), canvasCenter.Y + (int)(*joystickVizSize / 2 * input.Pitch) }, prevPos);
+			canvas.DrawLine({ canvasCenter.X + (int)(*joystickVizSize / 2 * input.Steer), canvasCenter.Y + (int)(*joystickVizSize / 2 * input.Pitch) }, prevPos);
 		}
 
 		prevPos = currentPos;


### PR DESCRIPTION
Fixes https://github.com/kcolton/JoystickSelfCheckPlugin/issues/1

Note: Only replaced `.Yaw` with `.Steer`, but GitHub shows nearly all lines as changed, because the file had mixed line endings. They should now be the same as for the rest of the project. Check with `git ls-files --eol`.